### PR TITLE
Admin e-mailadres instelbaar via .env

### DIFF
--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -14,7 +14,7 @@ class UsersTableSeeder extends Seeder
         DB::table('users')->insert(
             [
                 'name' => 'Administrator',
-                'email' => 'admin@bieponline.local',
+                'email' => '{{ config('app.admin') }}',
                 'password' => bcrypt('Admin123!'),
                 'created_at' => \Carbon\Carbon::now()->toDateTimeString(),
                 'updated_at' => \Carbon\Carbon::now()->toDateTimeString(),


### PR DESCRIPTION
Door de APP_EMAIL in te stellen via het .env bestand wordt dit adres ook automatisch gebruikt voor het administrator-account via de UserTableSeeder en voor op de helppagina.

Wanneer er geen email adres wordt ingevuld in het .env bestand wordt er ge-default naar admin@bieponline.local